### PR TITLE
Cleaning the test project and sync lib9c

### DIFF
--- a/NineChronicles.Standalone.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Standalone.Tests/GraphTypes/GraphQLTestBase.cs
@@ -112,7 +112,7 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
             return new LibplanetNodeService<T>(
                 properties,
                 new BlockPolicy<T>(),
-                async (chain, swarm, privateKey, cancellationToken) => { },
+                (chain, swarm, privateKey, cancellationToken) => Task.CompletedTask,
                 preloadProgress);
         }
 

--- a/NineChronicles.Standalone.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Standalone.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -119,9 +119,9 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
             // 2. NineChroniclesNodeService.ConfigureStandaloneContext(standaloneContext)를 호출합니다.
             // BlockChain 객체 공유 및 PreloadEnded, BootstrapEnded 이벤트 훅의 처리를 합니다.
             // BlockChain 객체 공유는 액션 타입이 달라 생략합니다.
-            service.BootstrapEnded.WaitAsync()
+            _ = service.BootstrapEnded.WaitAsync()
                 .ContinueWith(task => StandaloneContextFx.BootstrapEnded = true);
-            service.PreloadEnded.WaitAsync()
+            _ = service.PreloadEnded.WaitAsync()
                 .ContinueWith(task => StandaloneContextFx.PreloadEnded = true);
 
             var bootstrapEndedTask = service.BootstrapEnded.WaitAsync();
@@ -139,7 +139,7 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
             Assert.False(nodeStatus["bootstrapEnded"]);
             Assert.False(nodeStatus["preloadEnded"]);
 
-            service.StartAsync(cts.Token);
+            _ = service.StartAsync(cts.Token);
 
             await bootstrapEndedTask;
             await preloadEndedTask;

--- a/NineChronicles.Standalone.Tests/GraphTypes/StandaloneSubscriptionTest.cs
+++ b/NineChronicles.Standalone.Tests/GraphTypes/StandaloneSubscriptionTest.cs
@@ -83,7 +83,7 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
             var result = await ExecuteQueryAsync("subscription { preloadProgress { currentPhase totalPhase extra { type currentCount totalCount } } }");
             Assert.IsType<SubscriptionExecutionResult>(result);
 
-            service.StartAsync(cts.Token);
+            _ = service.StartAsync(cts.Token);
 
             await service.PreloadEnded.WaitAsync(cts.Token);
 
@@ -150,7 +150,7 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
             var stream = subscribeResult.Streams.Values.FirstOrDefault();
             Assert.NotNull(stream);
 
-            Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await Assert.ThrowsAsync<TimeoutException>(async () =>
             {
                 await stream.Take(1).Timeout(TimeSpan.FromMilliseconds(5000)).FirstAsync();
             });


### PR DESCRIPTION
This PR removes warnings related to async feature in the test project. it also synchronizes Lib9c to the latest.