### PR TITLE
Exit program when catches error

### DIFF
--- a/NineChronicles.Standalone.Executable/Program.cs
+++ b/NineChronicles.Standalone.Executable/Program.cs
@@ -193,14 +193,12 @@ namespace NineChronicles.Standalone.Executable
                     tasks.Add(
                         nineChroniclesNodeHostBuilder.RunConsoleAsync(Context.CancellationToken));
                 }
+                
+                await Task.WhenAll(tasks);
             }
             catch (Exception e)
             {
                 Log.Error(e, "Unexpected exception occurred during Run. {e}", e);
-            }
-            finally
-            {
-                await Task.WhenAll(tasks);
             }
 
 #if SENTRY || ! DEBUG


### PR DESCRIPTION
Process should be killed when node services were failed to execute.