### PR TITLE
Add HttpRequest to find specific peer on network

### DIFF
--- a/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
@@ -165,6 +165,13 @@ namespace Libplanet.Standalone.Hosting
             _miningCancellationTokenSource?.Cancel();
         }
 
+        public async Task<bool> CheckPeer(string addr)
+        {
+            Address address = new Address(addr);
+            var boundPeer = await Swarm.FindSpecificPeerAsync(address, -1);
+            return !(boundPeer is null);
+        }
+
         public Task StopAsync(CancellationToken cancellationToken)
         {
             _stopRequested = true;

--- a/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
@@ -167,7 +167,7 @@ namespace Libplanet.Standalone.Hosting
 
         public async Task<bool> CheckPeer(string addr)
         {
-            Address address = new Address(addr);
+            var address = new Address(addr);
             var boundPeer = await Swarm.FindSpecificPeerAsync(
                 address, -1, cancellationToken: _swarmCancellationToken);
             return !(boundPeer is null);

--- a/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
@@ -168,7 +168,8 @@ namespace Libplanet.Standalone.Hosting
         public async Task<bool> CheckPeer(string addr)
         {
             Address address = new Address(addr);
-            var boundPeer = await Swarm.FindSpecificPeerAsync(address, -1);
+            var boundPeer = await Swarm.FindSpecificPeerAsync(
+                address, -1, cancellationToken: _swarmCancellationToken);
             return !(boundPeer is null);
         }
 

--- a/NineChronicles.Standalone/Controllers/GraphQLController.cs
+++ b/NineChronicles.Standalone/Controllers/GraphQLController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
@@ -35,6 +36,8 @@ namespace NineChronicles.Standalone.Controllers
         public const string SetPrivateKeyEndpoint = "/set-private-key";
 
         public const string SetMiningEndpoint = "/set-mining";
+
+        public const string CheckPeerEndpoint = "/check-peer";
 
         public GraphQLController(StandaloneContext standaloneContext)
         {
@@ -105,6 +108,30 @@ namespace NineChronicles.Standalone.Controllers
             }
 
             return Ok($"Set mining status to {request.Mine}.");
+        }
+
+        [HttpPost(CheckPeerEndpoint)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> CheckPeer([FromBody] CheckPeerRequest request)
+        {
+            try
+            {
+                var exist = await StandaloneContext.NineChroniclesNodeService.CheckPeer(request.AddressString);
+                if (exist)
+                {
+                    return Ok($"Found peer {request.AddressString}.");
+                }
+                
+                return BadRequest($"No such peer {request.AddressString}");
+            }
+            catch (Exception e)
+            {
+                var msg = $"Unexpected error occurred during CheckPeer request. {e}";
+                // Unexpected Error.
+                Log.Warning(e, msg);
+                return BadRequest(msg);
+            }
         }
 
         private void NotifyRefillActionPoint(long newTipIndex)

--- a/NineChronicles.Standalone/Controllers/GraphQLController.cs
+++ b/NineChronicles.Standalone/Controllers/GraphQLController.cs
@@ -113,6 +113,7 @@ namespace NineChronicles.Standalone.Controllers
         [HttpPost(CheckPeerEndpoint)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> CheckPeer([FromBody] CheckPeerRequest request)
         {
             try
@@ -130,7 +131,7 @@ namespace NineChronicles.Standalone.Controllers
                 var msg = $"Unexpected error occurred during CheckPeer request. {e}";
                 // Unexpected Error.
                 Log.Warning(e, msg);
-                return BadRequest(msg);
+                return StatusCode(StatusCodes.Status500InternalServerError, msg);
             }
         }
 

--- a/NineChronicles.Standalone/NineChroniclesNodeService.cs
+++ b/NineChronicles.Standalone/NineChroniclesNodeService.cs
@@ -161,5 +161,7 @@ namespace NineChronicles.Standalone
         public void StartMining() => NodeService.StartMining(PrivateKey);
 
         public void StopMining() => NodeService.StopMining();
+        
+        public Task<bool> CheckPeer(string addr) => NodeService.CheckPeer(addr);
     }
 }

--- a/NineChronicles.Standalone/Requests/CheckPeerRequest.cs
+++ b/NineChronicles.Standalone/Requests/CheckPeerRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace NineChronicles.Standalone.Requests
+{
+  public struct CheckPeerRequest
+  {
+    public string AddressString { get; set; }
+  }
+}


### PR DESCRIPTION
Added new HttpRequest `/check-peer` that returns 200 if the target peer exists, otherwise 400.