### PR TITLE
Upgrade Libplanet to 0.10.0-dev.20200904141108

### DIFF
--- a/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
@@ -87,19 +87,14 @@ namespace Libplanet.Standalone.Hosting
                 Log.Debug($"chainId: {chainId}");
             }
 
-            // Since <https://github.com/planetarium/libplanet/pull/963> Libplanet became to unify
-            // actions renders and tip change events into one interface: IRenderer<T>.
-            // The LibplanetNodeServiceProperties.Render option purposes to turn off only action
-            // renders, but Libplanet's above patch made it unable to turn off only action renders
-            // and leave tip change events turn on.
-            // Passing a thunk implementation that leaves action renders blank and fill with
-            // only block renders to renderers in the current API is not equivalent giving
-            // render: false to BlockChain<T>() constructor in the old API, because it still
-            // evaluates actions in order to calculate states of every step, which leads low
-            // performance... and that's the reason why we've made
-            // LibplanetNodeServiceProperties.Render option.  So...:
-            // TODO: We should adjust Libplanet's IRenderer<T> interface so that we can only listen
-            // to tip change events and prevent actions to be evaluated.
+            if (_properties.Confirmations > 0)
+            {
+                renderers = renderers.Select(r => r is IActionRenderer<T> ar
+                    ? new DelayedActionRenderer<T>(ar, Store, _properties.Confirmations)
+                    : new DelayedRenderer<T>(r, Store, _properties.Confirmations)
+                );
+            }
+
             BlockChain = new BlockChain<T>(
                 policy: blockPolicy,
                 store: Store,

--- a/Libplanet.Standalone/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Standalone/Hosting/LibplanetNodeServiceProperties.cs
@@ -48,5 +48,7 @@ namespace Libplanet.Standalone.Hosting
         public bool Mpt { get; set; }
 
         public int Workers { get; set; } = 5;
+
+        public int Confirmations { get; set; } = 0;
     }
 }

--- a/Libplanet.Standalone/Libplanet.Standalone.csproj
+++ b/Libplanet.Standalone/Libplanet.Standalone.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Libplanet" Version="0.10.0-nightly.20200831" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="0.10.0-dev.20200827073450" />
+    <PackageReference Include="Libplanet" Version="0.10.0-dev.20200904141108" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="0.10.0-dev.20200904141108" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.1" />
   </ItemGroup>
 

--- a/Libplanet.Standalone/Libplanet.Standalone.csproj
+++ b/Libplanet.Standalone/Libplanet.Standalone.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Libplanet" Version="0.10.0-dev.20200827073450" />
+    <PackageReference Include="Libplanet" Version="0.10.0-nightly.20200831" />
     <PackageReference Include="Libplanet.RocksDBStore" Version="0.10.0-dev.20200827073450" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.1" />
   </ItemGroup>

--- a/NineChronicles.Standalone.Executable/Program.cs
+++ b/NineChronicles.Standalone.Executable/Program.cs
@@ -76,7 +76,13 @@ namespace NineChronicles.Standalone.Executable
             [Option("mpt", Description = "Flag to turn on the Merkle trie feature. It is experimental.")]
             bool mpt = false,
             [Option("workers", Description = "Number of workers to use in Swarm")]
-            int workers = 5
+            int workers = 5,
+            [Option(
+                "confirmations",
+                Description =
+                    "The number of required confirmations to recognize a block.  0 by default."
+            )]
+            int confirmations = 0
         )
         {
 #if SENTRY || ! DEBUG
@@ -167,7 +173,8 @@ namespace NineChronicles.Standalone.Executable
                         trustedAppProtocolVersionSigners,
                         noMiner,
                         mpt: mpt,
-                        workers: workers);
+                        workers: workers,
+                        confirmations: confirmations);
                 if (rpcServer)
                 {
                     rpcProperties = NineChroniclesNodeServiceProperties

--- a/NineChronicles.Standalone/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Standalone/Properties/NineChroniclesNodeServiceProperties.cs
@@ -35,7 +35,8 @@ namespace NineChronicles.Standalone.Properties
                 bool noMiner = false,
                 bool render = false,
                 bool mpt = false,
-                int workers = 5)
+                int workers = 5,
+                int confirmations = 0)
         {
             var privateKey = string.IsNullOrEmpty(privateKeyString)
                 ? new PrivateKey()
@@ -77,7 +78,8 @@ namespace NineChronicles.Standalone.Properties
                 MinimumDifficulty = minimumDifficulty,
                 Render = render,
                 Mpt = mpt,
-                Workers = workers
+                Workers = workers,
+                Confirmations = Math.Max(confirmations, 0),
             };
         }
 


### PR DESCRIPTION
Prerequisites: <https://github.com/planetarium/lib9c/pull/45>.

To use Libplanet's [delayed renderers][1], upgrades it to 0.10.0-dev.20200904141108.  Also added the `Confirmations` configuration.

[1]: https://github.com/planetarium/libplanet/pull/980