### PR TITLE
Configuration BlockPolicySource for AuthorizedMinersState

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# Read about the format of this file: <https://editorconfig.org/>
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/Libplanet.Standalone/Libplanet.Standalone.csproj
+++ b/Libplanet.Standalone/Libplanet.Standalone.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Libplanet" Version="0.10.0-dev.20200909110819" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="0.10.0-dev.20200909110819" />
+    <PackageReference Include="Libplanet" Version="0.10.0-dev.20200911094212" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="0.10.0-dev.20200911094212" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.1" />
   </ItemGroup>
 

--- a/NineChronicles.Standalone.Tests/GraphTypes/StandaloneMutationTest.cs
+++ b/NineChronicles.Standalone.Tests/GraphTypes/StandaloneMutationTest.cs
@@ -109,6 +109,7 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
                             GoldCurrencyState = new GoldCurrencyState(new Currency("NCG", 2, minter: null)),
                             GoldDistributions = new GoldDistribution[0],
                             TableSheets = new Dictionary<string, string>(),
+                            PendingActivationStates = new PendingActivationState[]{ },
                         },
                     }
                 );

--- a/NineChronicles.Standalone.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Standalone.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -320,6 +320,7 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
                             GoldCurrencyState = new GoldCurrencyState(new Currency("NCG", 2, minter: null)),
                             GoldDistributions = new GoldDistribution[0],
                             TableSheets = new Dictionary<string, string>(),
+                            PendingActivationStates = new PendingActivationState[]{ },
                         },
                     }
                 );

--- a/NineChronicles.Standalone/NineChroniclesNodeService.cs
+++ b/NineChronicles.Standalone/NineChroniclesNodeService.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Bencodex.Types;
 using Grpc.Core;
 using Libplanet.Action;
 using Libplanet.Blockchain;
@@ -132,6 +133,11 @@ namespace NineChronicles.Standalone
             {
                 var rawState = NodeService?.BlockChain?.GetState(ActivatedAccountsState.Address);
                 blockPolicySource.UpdateActivationSet(rawState);
+            }
+
+            if (NodeService?.BlockChain?.GetState(AuthorizedMinersState.Address) is Dictionary ams)
+            {
+                blockPolicySource.AuthorizedMinersState = new AuthorizedMinersState(ams);
             }
         }
 


### PR DESCRIPTION
This PR adds configuration for `AuthorizedMinersState` introduced by https://github.com/planetarium/lib9c/pull/60
