### PR TITLE
Report error via RPC when no any peers in routing table with seed peers given

### DIFF
--- a/Libplanet.Standalone.Tests/Hosting/LibplanetNodeServiceTest.cs
+++ b/Libplanet.Standalone.Tests/Hosting/LibplanetNodeServiceTest.cs
@@ -32,7 +32,8 @@ namespace Libplanet.Standalone.Tests.Hosting
                 blockPolicy: new BlockPolicy(),
                 renderers: null,
                 minerLoopAction: (chain, swarm, pk, ct) => Task.CompletedTask,
-                preloadProgress: null
+                preloadProgress: null,
+                exceptionHandlerAction:  (code, msg) => throw new Exception($"{code}, {msg}")
             );
 
             Assert.NotNull(service);
@@ -54,7 +55,8 @@ namespace Libplanet.Standalone.Tests.Hosting
                     blockPolicy: new BlockPolicy(),
                     renderers: null,
                     minerLoopAction: (chain, swarm, pk, ct) => Task.CompletedTask,
-                    preloadProgress: null
+                    preloadProgress: null,
+                    exceptionHandlerAction:  (code, msg) => throw new Exception($"{code}, {msg}")
                 );
             });
         }

--- a/Libplanet.Standalone/Libplanet.Standalone.csproj
+++ b/Libplanet.Standalone/Libplanet.Standalone.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/NineChronicles.Standalone.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Standalone.Tests/GraphTypes/GraphQLTestBase.cs
@@ -124,7 +124,8 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
                 blockPolicy: new BlockPolicy<T>(),
                 renderers: new[] { new DummyRenderer<T>() },
                 minerLoopAction: (chain, swarm, privateKey, _) => Task.CompletedTask,
-                preloadProgress: preloadProgress
+                preloadProgress: preloadProgress,
+                exceptionHandlerAction: (code, msg) => throw new Exception($"{code}, {msg}")
             );
         }
 

--- a/NineChronicles.Standalone/ActionEvaluationHub.cs
+++ b/NineChronicles.Standalone/ActionEvaluationHub.cs
@@ -47,5 +47,11 @@ namespace NineChronicles.Standalone
             Broadcast(group).OnReorgEnd(oldTip, newTip, branchpoint);
             await Task.CompletedTask;
         }
+
+        public async Task ReportExceptionAsync(int code, string message)
+        {
+            Broadcast(group).OnException(code, message);
+            await Task.CompletedTask;
+        }
     }
 }

--- a/NineChronicles.Standalone/ExceptionRenderer.cs
+++ b/NineChronicles.Standalone/ExceptionRenderer.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using NineChronicles.RPC.Shared.Exceptions;
+
+namespace NineChronicles.Standalone
+{
+    public class ExceptionRenderer
+    {
+        public readonly Subject<(RPCException, string)> ExceptionRenderSubject = new Subject<(RPCException, string)>();
+
+        public void RenderException(RPCException code, string msg)
+        {
+            ExceptionRenderSubject.OnNext((code, msg));
+        }
+
+        public IObservable<(RPCException, string)> EveryException() => ExceptionRenderSubject.AsObservable();
+    }
+}

--- a/NineChronicles.Standalone/NineChroniclesNodeService.cs
+++ b/NineChronicles.Standalone/NineChroniclesNodeService.cs
@@ -39,6 +39,8 @@ namespace NineChronicles.Standalone
 
         public ActionRenderer ActionRenderer { get; }
 
+        public ExceptionRenderer ExceptionRenderer { get; }
+
         public AsyncManualResetEvent BootstrapEnded => NodeService.BootstrapEnded;
 
         public AsyncManualResetEvent PreloadEnded => NodeService.PreloadEnded;
@@ -75,6 +77,7 @@ namespace NineChronicles.Standalone
             );
             BlockRenderer = blockPolicySource.BlockRenderer;
             ActionRenderer = blockPolicySource.ActionRenderer;
+            ExceptionRenderer = new ExceptionRenderer();
             var renderers = Properties.Render
                 ? new IRenderer<NineChroniclesActionType>[]
                 {
@@ -125,6 +128,11 @@ namespace NineChronicles.Standalone
                 renderers,
                 minerLoopAction,
                 preloadProgress,
+                (code, msg) =>
+                {
+                    ExceptionRenderer.RenderException(code, msg);
+                    Log.Error(msg);
+                },
                 ignoreBootstrapFailure
             );
 
@@ -148,6 +156,7 @@ namespace NineChronicles.Standalone
                         services.AddHostedService(provider => new ActionEvaluationPublisher(
                             BlockRenderer,
                             ActionRenderer,
+                            ExceptionRenderer,
                             IPAddress.Loopback.ToString(),
                             rpcProperties.RpcListenPort
                         ));


### PR DESCRIPTION
This patch implement interface for reporting errors via RPC, and send `NetworkException` when no any peers in node's routing table even the seed peers were given.

Please see also https://github.com/planetarium/NineChronicles.RPC.Shared/pull/5 and https://github.com/planetarium/NineChronicles.RPC.Shared/pull/6.