### PR TITLE
Report error via GraphQL when no any peers in routing table with seed peers given 

### DIFF
--- a/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
@@ -344,9 +344,9 @@ namespace Libplanet.Standalone.Hosting
                 {
                     if (grace == count)
                     {
-                        _exceptionHandlerAction(
-                            RPCException.NetworkException,
-                            "No any peers are connected even seed peers were given.");
+                        var message = "No any peers are connected even seed peers were given.";
+                        _exceptionHandlerAction(RPCException.NetworkException, message);
+                        _properties.NodeExceptionOccurred((int)RPCException.NetworkException, message);
                         break;
                     }
 

--- a/Libplanet.Standalone/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Standalone/Hosting/LibplanetNodeServiceProperties.cs
@@ -50,5 +50,7 @@ namespace Libplanet.Standalone.Hosting
         public int Workers { get; set; } = 5;
 
         public int Confirmations { get; set; } = 0;
+
+        public System.Action<int, string> NodeExceptionOccurred { get; set; }
     }
 }

--- a/NineChronicles.Standalone/GraphTypes/NodeExceptionType.cs
+++ b/NineChronicles.Standalone/GraphTypes/NodeExceptionType.cs
@@ -1,0 +1,19 @@
+﻿using GraphQL.Types;
+
+namespace NineChronicles.Standalone.GraphTypes
+{
+    public sealed class NodeExceptionType : ObjectGraphType<NodeException>
+    {
+        public NodeExceptionType()
+        {
+            Field<NonNullGraphType<IntGraphType>>(
+                name: "code",
+                description: "The code of NodeException.",
+                resolve: context => context.Source.Code);
+            Field<NonNullGraphType<StringGraphType>>(
+                name: "message",
+                description: "The message of NodeException.",
+                resolve: context => context.Source.Message);
+        }
+    }
+}

--- a/NineChronicles.Standalone/GraphTypes/StandaloneSubscription.cs
+++ b/NineChronicles.Standalone/GraphTypes/StandaloneSubscription.cs
@@ -139,6 +139,14 @@ namespace NineChronicles.Standalone.GraphTypes
                 Subscriber = new EventStreamResolver<Notification>(context =>
                     StandaloneContext.NotificationSubject.AsObservable()),
             });
+            AddField(new EventStreamFieldType
+            {
+                Name = "nodeException",
+                Type = typeof(NonNullGraphType<NodeExceptionType>),
+                Resolver = new FuncFieldResolver<NodeException>(context => context.Source as NodeException),
+                Subscriber = new EventStreamResolver<NodeException>(context =>
+                    StandaloneContext.NodeExceptionSubject.AsObservable()),
+            });
         }
 
         public void RegisterTipChangedSubscription()

--- a/NineChronicles.Standalone/NodeException.cs
+++ b/NineChronicles.Standalone/NodeException.cs
@@ -1,0 +1,10 @@
+﻿using Libplanet.Net;
+
+namespace NineChronicles.Standalone
+{
+    public class NodeException
+    {
+        public int Code;
+        public string Message;
+    }
+}

--- a/NineChronicles.Standalone/StandaloneContext.cs
+++ b/NineChronicles.Standalone/StandaloneContext.cs
@@ -18,6 +18,7 @@ namespace NineChronicles.Standalone
         public ReplaySubject<DifferentAppProtocolVersionEncounter> DifferentAppProtocolVersionEncounterSubject { get; }
             = new ReplaySubject<DifferentAppProtocolVersionEncounter>();
         public ReplaySubject<Notification> NotificationSubject { get; } = new ReplaySubject<Notification>(1);
+        public ReplaySubject<NodeException> NodeExceptionSubject { get; } = new ReplaySubject<NodeException>();
         public NineChroniclesNodeService NineChroniclesNodeService { get; set; }
         public NodeStatusType NodeStatus => new NodeStatusType()
         {

--- a/NineChronicles.Standalone/StandaloneServices.cs
+++ b/NineChronicles.Standalone/StandaloneServices.cs
@@ -37,6 +37,18 @@ namespace NineChronicles.Standalone
                     return false;
                 };
 
+            properties.Libplanet.NodeExceptionOccurred =
+                (code, message) =>
+                {
+                    standaloneContext.NodeExceptionSubject.OnNext(
+                        new NodeException
+                        {
+                            Code = code,
+                            Message = message,
+                        }
+                    );
+                };
+
             var service = new NineChroniclesNodeService(
                 properties.Libplanet,
                 properties.Rpc,


### PR DESCRIPTION
This patch implement interface for reporting errors via GraphQL, and send NodeException subscription when no any peers in node's routing table even the seed peers were given.