### PR TITLE
Reference Libplanet inside Lib9c instead of NuGet (retake)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
+        submodules: recursive
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
+        submodules: recursive
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/Libplanet.Standalone.Tests/Libplanet.Standalone.Tests.csproj
+++ b/Libplanet.Standalone.Tests/Libplanet.Standalone.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libplanet.Standalone/Libplanet.Standalone.csproj
+++ b/Libplanet.Standalone/Libplanet.Standalone.csproj
@@ -6,13 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Libplanet" Version="0.10.0-dev.20201006075405" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="0.10.0-dev.20201006075405" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Lib9c\Libplanet\Libplanet\Libplanet.csproj" />
+    <ProjectReference Include="..\Lib9c\Libplanet\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
     <ProjectReference Include="..\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared.csproj" />
   </ItemGroup>
-
 </Project>

--- a/NineChronicles.Standalone.Tests/NineChronicles.Standalone.Tests.csproj
+++ b/NineChronicles.Standalone.Tests/NineChronicles.Standalone.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As I closed the PR #87 by mistake, I open a new PR again.

See also:

- planetarium/lib9c#110
- PR planetarium/lib9c#126
- PR https://github.com/planetarium/nekoyume-unity/pull/2876