### PR TITLE
As verbose-level logs are ignored, log raw render events in debug-level

### DIFF
--- a/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
@@ -115,8 +115,8 @@ namespace Libplanet.Standalone.Hosting
                 // the innermost (after delayed) events:
                 ILogger logger = Log.ForContext("SubLevel", " RAW-RENDER-EVENT");
                 renderers = renderers.Select(r => r is IActionRenderer<T> ar
-                    ? new LoggedActionRenderer<T>(ar, logger, LogEventLevel.Verbose)
-                    : new LoggedRenderer<T>(r, logger, LogEventLevel.Verbose)
+                    ? new LoggedActionRenderer<T>(ar, logger, LogEventLevel.Debug)
+                    : new LoggedRenderer<T>(r, logger, LogEventLevel.Debug)
                 );
             }
 


### PR DESCRIPTION
Continued from #141.  As NineChronicles.Executable only prints logs equal to or higher than debug-level, I changed the log level of raw render events to debug (from verbose).