### PR TITLE
Add txId for transferAsset()

### DIFF
--- a/NineChronicles.Standalone.Tests/Common/ServiceBuilder.cs
+++ b/NineChronicles.Standalone.Tests/Common/ServiceBuilder.cs
@@ -1,0 +1,39 @@
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Libplanet.Standalone.Hosting;
+using Nekoyume.Action;
+using System.Collections.Immutable;
+
+namespace NineChronicles.Standalone.Tests.Common
+{
+    public static class ServiceBuilder
+    {
+        public static NineChroniclesNodeService CreateNineChroniclesNodeService(
+            Block<PolymorphicAction<ActionBase>> genesis
+        )
+        {
+            var privateKey = new PrivateKey();
+            var properties = new LibplanetNodeServiceProperties<PolymorphicAction<ActionBase>>
+            {
+                Host = System.Net.IPAddress.Loopback.ToString(),
+                AppProtocolVersion = default,
+                GenesisBlock = genesis,
+                StorePath = null,
+                StoreStatesCacheSize = 2,
+                PrivateKey = privateKey,
+                Port = null,
+                MinimumDifficulty = 4096,
+                NoMiner = true,
+                Render = false,
+                Peers = ImmutableHashSet<Peer>.Empty,
+                TrustedAppProtocolVersionSigners = null,
+            };
+            return new NineChroniclesNodeService(properties, null)
+            {
+                PrivateKey = privateKey
+            };
+        }
+    }
+}

--- a/NineChronicles.Standalone.Tests/GraphTypes/StandaloneMutationTest.cs
+++ b/NineChronicles.Standalone.Tests/GraphTypes/StandaloneMutationTest.cs
@@ -15,6 +15,7 @@ using Nekoyume.Action;
 using Nekoyume.Model;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using NineChronicles.Standalone.Tests.Common;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -107,7 +108,7 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
 
             Block<PolymorphicAction<ActionBase>> genesis =
                 MakeGenesisBlock(adminAddress, new Currency("NCG", 2, minters: null), activateAccounts);
-            NineChroniclesNodeService service = CreateNineChroniclesNodeService(genesis);
+            NineChroniclesNodeService service = ServiceBuilder.CreateNineChroniclesNodeService(genesis);
             StandaloneContextFx.NineChroniclesNodeService = service;
             StandaloneContextFx.BlockChain = service.Swarm.BlockChain;
 
@@ -148,7 +149,7 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
                     goldCurrency,
                     ImmutableHashSet<Address>.Empty
                 );
-            NineChroniclesNodeService service = CreateNineChroniclesNodeService(genesis);
+            NineChroniclesNodeService service = ServiceBuilder.CreateNineChroniclesNodeService(genesis);
             StandaloneContextFx.NineChroniclesNodeService = service;
             StandaloneContextFx.BlockChain = service.BlockChain;
 
@@ -341,7 +342,7 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
                     new Currency("NCG", 2, minters: null),
                     ImmutableHashSet<Address>.Empty
                 );
-            NineChroniclesNodeService service = CreateNineChroniclesNodeService(genesis);
+            NineChroniclesNodeService service = ServiceBuilder.CreateNineChroniclesNodeService(genesis);
 
             StandaloneContextFx.NineChroniclesNodeService = service;
             StandaloneContextFx.BlockChain = service.Swarm.BlockChain;
@@ -379,32 +380,6 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
             Block<PolymorphicAction<ActionBase>> mined =
                 await StandaloneContextFx.BlockChain.MineBlock(service.PrivateKey.ToAddress());
             Assert.Contains(tx, mined.Transactions);
-        }
-
-        private NineChroniclesNodeService CreateNineChroniclesNodeService(
-            Block<PolymorphicAction<ActionBase>> genesis
-        )
-        {
-            var privateKey = new PrivateKey();
-            var properties = new LibplanetNodeServiceProperties<PolymorphicAction<ActionBase>>
-            {
-                Host = System.Net.IPAddress.Loopback.ToString(),
-                AppProtocolVersion = default,
-                GenesisBlock = genesis,
-                StorePath = null,
-                StoreStatesCacheSize = 2,
-                PrivateKey = privateKey,
-                Port = null,
-                MinimumDifficulty = 4096,
-                NoMiner = true,
-                Render = false,
-                Peers = ImmutableHashSet<Peer>.Empty,
-                TrustedAppProtocolVersionSigners = null,
-            };
-            return new NineChroniclesNodeService(properties, null)
-            {
-                PrivateKey = privateKey
-            };
         }
 
         private Block<PolymorphicAction<ActionBase>> MakeGenesisBlock(

--- a/NineChronicles.Standalone/GraphTypes/NodeStatus.cs
+++ b/NineChronicles.Standalone/GraphTypes/NodeStatus.cs
@@ -7,6 +7,7 @@ using Libplanet;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
+using Libplanet.Store;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace NineChronicles.Standalone.GraphTypes
@@ -18,6 +19,8 @@ namespace NineChronicles.Standalone.GraphTypes
         public bool PreloadEnded { get; set; }
 
         public BlockChain<NCAction> BlockChain { get; set; }
+
+        public IStore Store { get; set; }
 
         public NodeStatusType()
         {
@@ -40,6 +43,11 @@ namespace NineChronicles.Standalone.GraphTypes
                 resolve: context => GetTopmostBlocks(context.Source.BlockChain)
                     .Take(context.GetArgument<int>("limit"))
                     .Select(BlockHeaderType.FromBlock)
+            );
+            Field<ListGraphType<TxIdType>>(
+                name: "stagedTxIds",
+                description: "Staged TxIds from the current node.",
+                resolve: context => context.Source.Store?.IterateStagedTransactionIds()
             );
             Field<NonNullGraphType<BlockHeaderType>>(name: "genesis",
                 resolve: context => BlockHeaderType.FromBlock(context.Source.BlockChain.Genesis));

--- a/NineChronicles.Standalone/GraphTypes/StandaloneMutation.cs
+++ b/NineChronicles.Standalone/GraphTypes/StandaloneMutation.cs
@@ -5,6 +5,7 @@ using Libplanet;
 using Libplanet.Assets;
 using Libplanet.Blockchain;
 using Libplanet.Crypto;
+using Libplanet.Store;
 using Libplanet.Tx;
 using Nekoyume.Action;
 using Nekoyume.Model.State;
@@ -68,7 +69,7 @@ namespace NineChronicles.Standalone.GraphTypes
                 }
             );
 
-            Field<NonNullGraphType<BooleanGraphType>>(
+            Field<TxIdType>(
                 name: "transferGold",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<AddressType>>
@@ -90,10 +91,10 @@ namespace NineChronicles.Standalone.GraphTypes
                         var msg = "No private key was loaded.";
                         context.Errors.Add(new ExecutionError(msg));
                         Log.Error(msg);
-                        return false;
+                        return null;
                     }
 
-                    BlockChain<NCAction> blockChain = service.Swarm.BlockChain;
+                    BlockChain<NCAction> blockChain = service.BlockChain;
                     var currency = new GoldCurrencyState(
                         (Dictionary)blockChain.GetState(GoldCurrencyState.Address)
                     ).Currency;
@@ -102,7 +103,7 @@ namespace NineChronicles.Standalone.GraphTypes
 
                     Address recipient = context.GetArgument<Address>("recipient");
 
-                    blockChain.MakeTransaction(
+                    Transaction<NCAction> tx = blockChain.MakeTransaction(
                         privateKey,
                         new NCAction[]
                         {
@@ -113,7 +114,7 @@ namespace NineChronicles.Standalone.GraphTypes
                             ),
                         }
                     );
-                    return true;
+                    return tx.Id;
                 }
             );
         }

--- a/NineChronicles.Standalone/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Standalone/GraphTypes/StandaloneQuery.cs
@@ -54,6 +54,7 @@ namespace NineChronicles.Standalone.GraphTypes
                     BootstrapEnded = standaloneContext.BootstrapEnded,
                     PreloadEnded = standaloneContext.PreloadEnded,
                     BlockChain = standaloneContext.BlockChain,
+                    Store = standaloneContext.Store,
                 }
             );
 

--- a/NineChronicles.Standalone/GraphTypes/TxIdType.cs
+++ b/NineChronicles.Standalone/GraphTypes/TxIdType.cs
@@ -1,0 +1,50 @@
+using GraphQL.Language.AST;
+using GraphQL.Types;
+using Libplanet;
+using Libplanet.Tx;
+using System;
+
+namespace NineChronicles.Standalone.GraphTypes
+{
+    public class TxIdType : StringGraphType
+    {
+        public TxIdType()
+        {
+            Name = "TxId";
+        }
+
+        public override object Serialize(object value)
+        {
+            if (value is TxId txId)
+            {
+                return txId.ToString();
+            }
+
+            return value;
+        }
+
+        public override object ParseValue(object value)
+        {
+            switch (value)
+            {
+                case null:
+                    return null;
+                case string hex:
+                    return new TxId(ByteUtil.ParseHex(hex));
+                default:
+                    throw new ArgumentException(
+                        $"Expected a hexadecimal string but {value}", nameof(value));
+            }
+        }
+
+        public override object ParseLiteral(IValue value)
+        {
+            if (value is StringValue)
+            {
+                return ParseValue(value.Value);
+            }
+
+            return null;
+        }
+    }
+}

--- a/NineChronicles.Standalone/NineChroniclesNodeService.cs
+++ b/NineChronicles.Standalone/NineChroniclesNodeService.cs
@@ -16,6 +16,7 @@ using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net;
 using Libplanet.Standalone.Hosting;
+using Libplanet.Store;
 using MagicOnion.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -49,6 +50,10 @@ namespace NineChronicles.Standalone
         public AsyncManualResetEvent PreloadEnded => NodeService.PreloadEnded;
 
         public Swarm<NineChroniclesActionType> Swarm => NodeService?.Swarm;
+
+        public BlockChain<NineChroniclesActionType> BlockChain => NodeService?.BlockChain;
+
+        public IStore Store => NodeService?.Store;
 
         public PrivateKey PrivateKey { get; set; }
 

--- a/NineChronicles.Standalone/StandaloneContext.cs
+++ b/NineChronicles.Standalone/StandaloneContext.cs
@@ -2,6 +2,7 @@ using System.Reactive.Subjects;
 using Libplanet.Blockchain;
 using Libplanet.KeyStore;
 using Libplanet.Net;
+using Libplanet.Store;
 using NineChronicles.Standalone.GraphTypes;
 using NineChroniclesActionType = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
@@ -25,5 +26,7 @@ namespace NineChronicles.Standalone
             BootstrapEnded = BootstrapEnded,
             PreloadEnded = PreloadEnded,
         };
+
+        public IStore Store { get; internal set; }
     }
 }

--- a/NineChronicles.Standalone/StandaloneServices.cs
+++ b/NineChronicles.Standalone/StandaloneServices.cs
@@ -72,6 +72,7 @@ namespace NineChronicles.Standalone
             if (!(standaloneContext is null))
             {
                 standaloneContext.BlockChain = service.Swarm.BlockChain;
+                standaloneContext.Store = service.Store;
                 service.BootstrapEnded.WaitAsync().ContinueWith((task) =>
                 {
                     standaloneContext.BootstrapEnded = true;


### PR DESCRIPTION
This PR adds TxId of created tx for `transferAsset()` mutation.

and, it also adds `stagedTxIds ` field to `nodeStatus` to query current staged transactions. (it can be useful when checking tx is applied).