### PR TITLE
Throw error via graphql when tip is stale

### DIFF
--- a/Libplanet.Standalone/Hosting/DevLibplanetNodeService.cs
+++ b/Libplanet.Standalone/Hosting/DevLibplanetNodeService.cs
@@ -91,7 +91,7 @@ namespace Libplanet.Standalone.Hosting
             bool preload = true;
             while (!cancellationToken.IsCancellationRequested && !_stopRequested)
             {
-                var tasks = new List<Task> { StartSwarm(preload, cancellationToken), CheckSwarm(cancellationToken) };
+                var tasks = new List<Task> { StartSwarm(preload, cancellationToken), CheckMessage(cancellationToken) };
                 if (Properties.Peers.Any()) 
                 {
                     tasks.Add(CheckPeerTable(cancellationToken));

--- a/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
@@ -400,9 +400,7 @@ namespace Libplanet.Standalone.Hosting
                         $"Chain's tip is too low. (demand: {Swarm.BlockDemand?.Header.Index}, " +
                         $"actual: {BlockChain.Tip?.Index}, buffer: {buffer})";
                     Log.Error(message);
-                    // TODO: Now only send to launcher because now it restarts. Should send through
-                    // gRPC also when launcher became not to relaunch.
-                    Properties.NodeExceptionOccurred((int)RPCException.ChainTooLowException, message);
+                    Properties.NodeExceptionOccurred(NodeExceptionType.DemandTooHigh, message);
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();
@@ -420,9 +418,11 @@ namespace Libplanet.Standalone.Hosting
                 {
                     if (grace == count)
                     {
-                        var message = "No any peers are connected even seed peers were given.";
-                        _exceptionHandlerAction(RPCException.NetworkException, message);
-                        Properties.NodeExceptionOccurred((int)RPCException.NetworkException, message);
+                        var message = "No any peers are connected even seed peers were given. " +
+                                     $"(grace: {grace}";
+                        Log.Error(message);
+                        // _exceptionHandlerAction(RPCException.NetworkException, message);
+                        Properties.NodeExceptionOccurred(NodeExceptionType.NoAnyPeer, message);
                     }
 
                     count++;

--- a/Libplanet.Standalone/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Standalone/Hosting/LibplanetNodeServiceProperties.cs
@@ -51,7 +51,7 @@ namespace Libplanet.Standalone.Hosting
 
         public int Confirmations { get; set; } = 0;
 
-        public System.Action<int, string> NodeExceptionOccurred { get; set; }
+        public System.Action<NodeExceptionType, string> NodeExceptionOccurred { get; set; }
 
         public int MaximumTransactions { get; set; } = 100;
     }

--- a/Libplanet.Standalone/NodeException.cs
+++ b/Libplanet.Standalone/NodeException.cs
@@ -1,8 +1,25 @@
 ﻿namespace Libplanet.Standalone
 {
+    public enum NodeExceptionType
+    {
+        NoAnyPeer = 0x01,
+        
+        DemandTooHigh = 0x02,
+        
+        TipNotChange = 0x03,
+        
+        MessageNotReceived = 0x04,
+    }
+    
     public class NodeException
     {
-        public int Code;
-        public string Message;
+        public readonly int Code;
+        public readonly string Message;
+        
+        public NodeException(NodeExceptionType code, string message)
+        {
+            Code = (int)code;
+            Message = message;
+        }
     }
 }

--- a/Libplanet.Standalone/NodeException.cs
+++ b/Libplanet.Standalone/NodeException.cs
@@ -1,6 +1,4 @@
-﻿using Libplanet.Net;
-
-namespace NineChronicles.Standalone
+﻿namespace Libplanet.Standalone
 {
     public class NodeException
     {

--- a/NineChronicles.Standalone.Tests/GraphTypes/StandaloneSubscriptionTest.cs
+++ b/NineChronicles.Standalone.Tests/GraphTypes/StandaloneSubscriptionTest.cs
@@ -13,6 +13,7 @@ using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net;
+using Libplanet.Standalone;
 using Libplanet.Standalone.Hosting;
 using NineChronicles.Standalone.Tests.Common.Actions;
 using Xunit;

--- a/NineChronicles.Standalone.Tests/GraphTypes/StandaloneSubscriptionTest.cs
+++ b/NineChronicles.Standalone.Tests/GraphTypes/StandaloneSubscriptionTest.cs
@@ -210,20 +210,14 @@ namespace NineChronicles.Standalone.Tests.GraphTypes
                 await stream.Take(1).Timeout(TimeSpan.FromMilliseconds(5000)).FirstAsync();
             });
 
-            const int code = 0xcc;
+            const NodeExceptionType code = (NodeExceptionType)0x01;
             const string message = "This is test message.";
-            StandaloneContextFx.NodeExceptionSubject.OnNext(
-                new NodeException()
-                {
-                    Code = code,
-                    Message = message,
-                }
-            );
+            StandaloneContextFx.NodeExceptionSubject.OnNext(new NodeException(code, message));
             var rawEvents = await stream.Take(1);
             var rawEvent = (Dictionary<string, object>)rawEvents.Data;
             var nodeException =
                 (Dictionary<string, object>)rawEvent["nodeException"];
-            Assert.Equal(code, nodeException["code"]);
+            Assert.Equal((int)code, nodeException["code"]);
             Assert.Equal(message, nodeException["message"]);
         }
     }

--- a/NineChronicles.Standalone/GraphTypes/NodeExceptionType.cs
+++ b/NineChronicles.Standalone/GraphTypes/NodeExceptionType.cs
@@ -1,4 +1,5 @@
 ﻿using GraphQL.Types;
+using Libplanet.Standalone;
 
 namespace NineChronicles.Standalone.GraphTypes
 {

--- a/NineChronicles.Standalone/GraphTypes/StandaloneSubscription.cs
+++ b/NineChronicles.Standalone/GraphTypes/StandaloneSubscription.cs
@@ -13,6 +13,7 @@ using Lib9c.Renderer;
 using Libplanet;
 using Libplanet.Blockchain;
 using Libplanet.Net;
+using Libplanet.Standalone;
 using Nekoyume.Action;
 using Log = Serilog.Log;
 

--- a/NineChronicles.Standalone/StandaloneContext.cs
+++ b/NineChronicles.Standalone/StandaloneContext.cs
@@ -2,6 +2,7 @@ using System.Reactive.Subjects;
 using Libplanet.Blockchain;
 using Libplanet.KeyStore;
 using Libplanet.Net;
+using Libplanet.Standalone;
 using Libplanet.Store;
 using NineChronicles.Standalone.GraphTypes;
 using NineChroniclesActionType = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;

--- a/NineChronicles.Standalone/StandaloneServices.cs
+++ b/NineChronicles.Standalone/StandaloneServices.cs
@@ -46,11 +46,7 @@ namespace NineChronicles.Standalone
                 (code, message) =>
                 {
                     standaloneContext.NodeExceptionSubject.OnNext(
-                        new NodeException
-                        {
-                            Code = code,
-                            Message = message,
-                        }
+                        new NodeException(code, message)
                     );
                 };
 

--- a/NineChronicles.Standalone/StandaloneServices.cs
+++ b/NineChronicles.Standalone/StandaloneServices.cs
@@ -1,5 +1,6 @@
 using System;
 using Libplanet.Net;
+using Libplanet.Standalone;
 using NineChronicles.Standalone.Properties;
 
 namespace NineChronicles.Standalone


### PR DESCRIPTION
Additionally, it became not to use `RPCException` in graphql. Now uses `NodeExceptionType` instead.