### PR TITLE
Remove build step from Actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,5 @@ jobs:
         dotnet-version: 3.1.301
     - name: Install dependencies
       run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
+    - name: Build and test
+      run: dotnet test --configuration Release --no-restore --verbosity normal

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,10 +23,8 @@ jobs:
         dotnet-version: 3.1.301
     - name: Install dependencies
       run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
+    - name: Build and test
+      run: dotnet test --configuration Release --no-restore --verbosity normal
     - name: Push Image
       uses: kciter/aws-ecr-action@v1
       with:


### PR DESCRIPTION
We can remove the build step because the build is done in the test step.