### PR TITLE
Catch up Libplanet's upstream & limit block size

### DIFF
--- a/Libplanet.Standalone.Tests/Hosting/LibplanetNodeServiceTest.cs
+++ b/Libplanet.Standalone.Tests/Hosting/LibplanetNodeServiceTest.cs
@@ -67,6 +67,10 @@ namespace Libplanet.Standalone.Tests.Hosting
         {
             public IAction BlockAction => null;
 
+            public int MaxTransactionsPerBlock => int.MaxValue;
+
+            public int GetMaxBlockBytes(long index) => int.MaxValue;
+
             public bool DoesTransactionFollowsPolicy(
                 Transaction<DummyAction> transaction,
                 BlockChain<DummyAction> blockChain

--- a/NineChronicles.Standalone/ReorgPolicy.cs
+++ b/NineChronicles.Standalone/ReorgPolicy.cs
@@ -17,6 +17,10 @@ namespace NineChronicles.Standalone
             _difficulty = difficulty;
         }
 
+        public int MaxTransactionsPerBlock => int.MaxValue;
+
+        public int GetMaxBlockBytes(long index) => int.MaxValue;
+
         public bool DoesTransactionFollowsPolicy(
             Transaction<PolymorphicAction<ActionBase>> transaction,
             BlockChain<PolymorphicAction<ActionBase>> blockChain


### PR DESCRIPTION
This should be merged *after* <https://github.com/planetarium/lib9c/pull/220> & <https://github.com/planetarium/libplanet/pull/1102> are merged.