### PR TITLE
fix: call _preloadStatusHandlerAction when peer is none

### DIFF
--- a/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Standalone/Hosting/LibplanetNodeService.cs
@@ -328,8 +328,10 @@ namespace Libplanet.Standalone.Hosting
             }
             else if (preload)
             {
+                _preloadStatusHandlerAction(true);
                 BootstrapEnded.Set();
                 PreloadEnded.Set();
+                _preloadStatusHandlerAction(false);
             }
 
             async Task ReconnectToSeedPeers(CancellationToken token)


### PR DESCRIPTION
SSIA