### PR TITLE
feat(logging): support Cognito identity credential

### DIFF
--- a/NineChronicles.Standalone.Executable/NineChronicles.Standalone.Executable.csproj
+++ b/NineChronicles.Standalone.Executable/NineChronicles.Standalone.Executable.csproj
@@ -8,6 +8,7 @@
   
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.5.0.37" />
+    <PackageReference Include="AWSSDK.CognitoIdentity" Version="3.5.1.2" />
     <PackageReference Include="Cocona.Lite" Version="1.3.*" />
     <PackageReference Include="Sentry.Serilog" Version="2.1.*" />
   </ItemGroup>

--- a/NineChronicles.Standalone.Executable/Program.cs
+++ b/NineChronicles.Standalone.Executable/Program.cs
@@ -139,10 +139,21 @@ namespace NineChronicles.Standalone.Executable
                     o.InitializeSdk = false;
                 });
 #endif
-            if ((!(awsAccessKey is null) && !(awsSecretKey is null)) ^ !(awsCognitoIdentity is null) && !(awsRegion is null))
+            bool useBasicAwsCredentials = !(awsAccessKey is null) && !(awsSecretKey is null);
+            bool useCognitoCredentials = !(awsCognitoIdentity is null);
+            if (useBasicAwsCredentials && useCognitoCredentials)
+            {
+                const string message =
+                    "You must choose to use only one credential between basic credential " +
+                    "(i.e., --aws-access-key, --aws-secret-key) and " +
+                    "Cognito credential (i.e., --aws-cognito-identity).";
+                throw new CommandExitedException(message, -1);
+            }
+
+            if (useBasicAwsCredentials ^ useCognitoCredentials  && !(awsRegion is null))
             {
                 var regionEndpoint = RegionEndpoint.GetBySystemName(awsRegion);
-                AWSCredentials credentials = !(awsCognitoIdentity is null)
+                AWSCredentials credentials = useCognitoCredentials
                     ? (AWSCredentials)new CognitoAWSCredentials(awsCognitoIdentity, regionEndpoint)
                     : (AWSCredentials)new BasicAWSCredentials(awsAccessKey, awsSecretKey);
 

--- a/NineChronicles.Standalone.Executable/Program.cs
+++ b/NineChronicles.Standalone.Executable/Program.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon;
+using Amazon.CognitoIdentity;
 using Amazon.Runtime;
 using Cocona;
 using Libplanet;
@@ -112,6 +113,8 @@ namespace NineChronicles.Standalone.Executable
             int reorgInterval = 0,
             [Option(Description = "The log minimum level during standalone execution.")]
             string logMinimumLevel = "debug",
+            [Option(Description = "The Cognito identity for AWS CloudWatch logging.")]
+            string awsCognitoIdentity = null,
             [Option(Description = "The access key for AWS CloudWatch logging.")]
             string awsAccessKey = null,
             [Option(Description = "The secret key for AWS CloudWatch logging.")]
@@ -136,10 +139,12 @@ namespace NineChronicles.Standalone.Executable
                     o.InitializeSdk = false;
                 });
 #endif
-            if (!(awsAccessKey is null) && !(awsSecretKey is null) && !(awsRegion is null))
+            if ((!(awsAccessKey is null) && !(awsSecretKey is null)) ^ !(awsCognitoIdentity is null) && !(awsRegion is null))
             {
-                var credentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
                 var regionEndpoint = RegionEndpoint.GetBySystemName(awsRegion);
+                AWSCredentials credentials = !(awsCognitoIdentity is null)
+                    ? (AWSCredentials)new CognitoAWSCredentials(awsCognitoIdentity, regionEndpoint)
+                    : (AWSCredentials)new BasicAWSCredentials(awsAccessKey, awsSecretKey);
 
                 var guid = LoadAWSSinkGuid() ?? Guid.NewGuid();
                 StoreAWSSinkGuid(guid);

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 ```
 $ dotnet run --project ./NineChronicles.Standalone.Executable/ -- --help
 
-Usage: NineChronicles.Standalone.Executable [--no-miner] [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <Nullable`1>] [--minimum-difficulty <Int32>] [--private-key <String>] [--store-type <String>] [--store-path <String>] [--ice-server <String>...] [--peer <String>...] [--no-trusted-state-validators] [--trusted-app-protocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [--graphql-host <String>] [--graphql-port <Nullable`1>] [--libplanet-node] [--workers <Int32>] [--confirmations <Int32>] [--max-transactions <Int32>] [--strict-rendering] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--log-minimum-level <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--help] [--version]
+Usage: NineChronicles.Standalone.Executable [--no-miner] [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <Nullable`1>] [--minimum-difficulty <Int32>] [--private-key <String>] [--store-type <String>] [--st
+ore-path <String>] [--ice-server <String>...] [--peer <String>...] [--no-trusted-state-validators] [--trusted-app-protocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [
+--graphql-host <String>] [--graphql-port <Nullable`1>] [--libplanet-node] [--workers <Int32>] [--confirmations <Int32>] [--max-transactions <Int32>] [--strict-rendering] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--log-m
+inimum-level <String>] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--help] [--version]
 
 Run standalone application with options.
 
@@ -38,6 +41,7 @@ Options:
   --dev.block-interval <Int32>                             The time interval between blocks. It's unit is milliseconds. Works only when dev mode is on.  10000 (ms) by default. (Default: 10000)
   --dev.reorg-interval <Int32>                             The size of reorg interval. Works only when dev mode is on.  0 by default. (Default: 0)
   --log-minimum-level <String>                             The log minimum level during standalone execution. (Default: debug)
+  --aws-cognito-identity <String>                          The Cognito identity for AWS CloudWatch logging. (Default: )
   --aws-access-key <String>                                The access key for AWS CloudWatch logging. (Default: )
   --aws-secret-key <String>                                The secret key for AWS CloudWatch logging. (Default: )
   --aws-region <String>                                    The AWS region for AWS CloudWatch (e.g., us-east-1, ap-northeast-2). (Default: )


### PR DESCRIPTION
It supports [AWS Cognito credentials](https://aws.amazon.com/ko/cognito/).

To use this feature, you *MUST* use only one crendtial method between basic credential (i.e., access key & secret key) and Cognito credential (i.e., Cognito identity).