### PR TITLE
remove host and port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ COPY --from=build-env /app/out .
 
 VOLUME /data
 
-ENTRYPOINT ["dotnet", "NineChronicles.Standalone.Executable.dll", "--host", "0.0.0.0", "--port", "31234"]
+ENTRYPOINT ["dotnet", "NineChronicles.Standalone.Executable.dll"]


### PR DESCRIPTION
This PR removes unnecessary parameters when building the 9c-headless image and enables the Docker container to run on EC2 without an elastic IP and use the TURN server.