### PR TITLE
Fix BlockChainService.GetTip() to return whole block

### DIFF
--- a/NineChronicles.Headless/BlockChainService.cs
+++ b/NineChronicles.Headless/BlockChainService.cs
@@ -113,7 +113,7 @@ namespace NineChronicles.Headless
 
         public UnaryResult<byte[]> GetTip()
         {
-            Bencodex.Types.Dictionary headerDict = _blockChain.Tip.MarshalBlockHeader();
+            Bencodex.Types.Dictionary headerDict = _blockChain.Tip.MarshalBlock();
             byte[] headerBytes = Codec.Encode(headerDict);
             return UnaryResult(headerBytes);
         }


### PR DESCRIPTION
This PR changes the return value of `BlockChainService.GetTip()` from marshaled block header to marshaled whole block to unify code for block rendering APIs