### PR TITLE
**Fix Typo in `JwtAuthenticationMiddleware.cs`**

### DIFF
--- a/NineChronicles.Headless/Middleware/JwtAuthenticationMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/JwtAuthenticationMiddleware.cs
@@ -56,7 +56,7 @@ public class JwtAuthenticationMiddleware : IMiddleware
                 context.Response.ContentType = "application/json";
                 await context.Response.WriteAsync(
                     JsonConvert.SerializeObject(
-                        new { errpr = e.Message }
+                        new { error = e.Message }
                         ));
                 return;
             }


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `JwtAuthenticationMiddleware.cs`**

## Description  
This pull request resolves a typo in the `JwtAuthenticationMiddleware.cs` file to ensure proper naming and improve clarity in the JSON response.

### Changes Made:
- **File Modified:** `NineChronicles.Headless/Middleware/JwtAuthenticationMiddleware.cs`
- **Summary of Changes:**
  - Corrected the typo "errpr" to "error" in the JSON response object.

## Related Issues  
N/A

## Checklist  
- [x] Fixed the typo in the middleware code.
- [x] Verified that the corrected code maintains functionality and does not introduce errors.

## Testing  
- Confirmed the middleware generates the corrected JSON response.

## Additional Notes  
This fix ensures that the JSON response is accurate and adheres to standard error field naming conventions, improving debugging and API integration.

---

**Allow edits by maintainers:** [x]
