### PR TITLE
fix(publisher): guarantee client disposal when LeaveAsync throws

### DIFF
--- a/NineChronicles.Headless/ActionEvaluationPublisher.cs
+++ b/NineChronicles.Headless/ActionEvaluationPublisher.cs
@@ -267,7 +267,17 @@ namespace NineChronicles.Headless
             if (_clients.TryGetValue(clientAddress, out Client? client) && client is { })
             {
                 Log.Information("[{ClientAddress}] RemoveClient", clientAddress);
-                await client.LeaveAsync();
+                try
+                {
+                    await client.LeaveAsync();
+                }
+                catch (Exception e)
+                {
+                    Log.Warning(
+                        e,
+                        "[{ClientAddress}] LeaveAsync failed (hub likely already disposed); proceeding to dispose",
+                        clientAddress);
+                }
                 await client.DisposeAsync();
                 _clients.TryRemove(clientAddress, out _);
             }


### PR DESCRIPTION
## Summary

`ActionEvaluationPublisher.RemoveClient(Address)` calls `await client.LeaveAsync()` before `DisposeAsync()` / `_clients.TryRemove(...)`. When the gRPC streaming hub is already disposed at the time of disconnect (common for ungraceful disconnects, app force-quits, network drops), `LeaveAsync()` throws via `MagicOnion.Client.StreamingHubClientBase.ThrowIfDisposed()`. The exception escapes `RemoveClient` and the cleanup steps below it never run, leaving zombie `Client` entries in `_clients` with their per-client subscriptions (`_blockSubscribe`, `_actionEveryRenderSubscribe`, …) still alive.

Each zombie's subscription keeps trying to `BroadcastRenderBlockAsync` / `BroadcastRenderAsync` on a dead hub on every new block, and these accumulate on `NewThreadScheduler`. In the field this manifested as gRPC tip stalling on healthy clients while GraphQL `nodeStatus.tip` polling continued to report fresh tips — pod restart was needed to recover.

## Observation

Today on a heimdall mainnet RPC pod (`remote-headless-1`), we saw 21 of these exceptions in a 10-minute window while a sibling pod (`remote-headless-2`) saw 0:

\`\`\`
MagicOnion.Client.StreamingHubClientBase\`2.ThrowIfDisposed()
MagicOnion.Client.StreamingHubClientBase\`2.WriteMessageWithResponseAsync[TRequest,TResponse](Int32 methodId, TRequest message)
NineChronicles.Headless.ActionEvaluationPublisher.RemoveClient(Address clientAddress)
   in /app/NineChronicles.Headless/ActionEvaluationPublisher.cs:line 270
NineChronicles.Headless.ActionEvaluationPublisher.RemoveClient(String clientAddressHex)
   in /app/NineChronicles.Headless/ActionEvaluationPublisher.cs:line 288
\`\`\`

The outer caller at line 281 has its own try/catch and successfully logs the exception — but \`_clients.TryRemove\` never runs, so zombies pile up.

## Change

Wrap \`LeaveAsync\` in try/catch and log as warning, then fall through to \`DisposeAsync\` + \`TryRemove\` so cleanup is unconditional. \`LeaveAsync\` is a best-effort notification to the peer that we're leaving; if the underlying transport is already gone, there's nothing to notify, and the local-side cleanup is what actually matters.

## Test plan

- [ ] Unit / integration: simulate a client whose hub is disposed before \`RemoveClient\` is invoked and confirm the entry is removed from \`_clients\`
- [ ] Soak on internal RPC: confirm `ninechronicles_rpc_clients_count` no longer drifts upward over time as ungraceful disconnects occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)