### PR TITLE
feat(rpc): opt-in HTTP/2 keepalive PING via env var

### DIFF
--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -97,6 +97,17 @@ namespace NineChronicles.Headless
                 {
                     hostBuilder.ConfigureKestrel(options =>
                     {
+                        // HTTP/2 keepalive PING to detect zombie gRPC connections.
+                        // Disabled by default (0 = Kestrel default of TimeSpan.MaxValue) so behavior is unchanged
+                        // until operators opt in per environment via Helm values.
+                        if (int.TryParse(
+                                Environment.GetEnvironmentVariable("RPC_KEEPALIVE_PING_DELAY_SECONDS"),
+                                out var keepAlivePingDelaySeconds) && keepAlivePingDelaySeconds > 0)
+                        {
+                            options.Limits.Http2.KeepAlivePingDelay =
+                                TimeSpan.FromSeconds(keepAlivePingDelaySeconds);
+                        }
+
                         options.ListenAnyIP(properties.RpcListenPort, listenOptions =>
                         {
                             listenOptions.Protocols = HttpProtocols.Http2;


### PR DESCRIPTION
## Summary

Adds an opt-in `RPC_KEEPALIVE_PING_DELAY_SECONDS` environment variable that, when set to a positive integer, makes Kestrel actively probe idle HTTP/2 gRPC connections with PING frames. Defaults to disabled (unset / `0`), so behavior is unchanged until operators opt in per environment.

## Why

Kestrel's default `Http2.KeepAlivePingDelay` is `TimeSpan.MaxValue`, so the RPC server never sends keepalive PINGs to clients. Combined with the Unity client also lacking gRPC keepalive options (planetarium/NineChronicles#7264), dead/zombie connections sit in `ActionEvaluationPublisher._clients` until a TCP RST eventually arrives — which may take minutes (NAT/proxy idle drop) or effectively never (network partition without RST).

Practical symptoms this addresses:
- Zombie clients keep receiving broadcast work the server then has to retry / dispose (see #2760 `LeaveAsync` guard — this PR shortens the time before that fallback triggers)
- Block render broadcasts incur unnecessary serialization/compression cost for clients that are gone
- During backend hiccups (e.g. libplanet 5.5.2 NetMQ 1s timeout bursts) the gap between "client is gone" and "server knows it" can be tens of minutes

## What

`NineChronicles.Headless/HostBuilderExtensions.cs`:

```csharp
if (int.TryParse(
        Environment.GetEnvironmentVariable("RPC_KEEPALIVE_PING_DELAY_SECONDS"),
        out var keepAlivePingDelaySeconds) && keepAlivePingDelaySeconds > 0)
{
    options.Limits.Http2.KeepAlivePingDelay =
        TimeSpan.FromSeconds(keepAlivePingDelaySeconds);
}
```

- `KeepAlivePingTimeout` is intentionally left at Kestrel's default of **20 s**, so dead detection budget = `delay + 20s` (e.g. `30s` env → ~50 s max).
- The env-variable form makes it possible to:
  - ship the image to all pods first with no behavior change,
  - then flip a single pod / namespace via Helm values for staged validation,
  - and roll back without rebuilding the image.

## Rollout plan

1. Merge → CI builds new image
2. 9c-infra: set `RPC_KEEPALIVE_PING_DELAY_SECONDS=30` on **9c-internal `remote-headless-1`** only. Observe 24–48 h.
3. Apply to **mainnet `odin/remote-headless-3`** (single pod via StatefulSet partition or per-pod env). Observe 24–48 h. Effect should be most visible here because odin pods currently see the highest NetMQ 1s timeout volume (~488 hits / 20k log lines), which correlates with broadcast pressure.
4. Roll out to remaining mainnet odin pods, then heimdall.
5. Once stable, consider raising the value to `60` if mobile-side GC pauses or other false positives appear, or leave at `30`.

## Validation signals

- `ActionEvaluationPublisher._clients` size over time
- `LeaveAsync` / `RemoveClient` log frequency (expected: short-term spike then steady-state lower)
- broadcast iteration latency (expected: lower variance)
- nginx access log distribution for `/` (the gRPC virtual host) — `499`/`502` rates and per-request time
- no spurious client-side disconnects in mainnet (sample Player.log from internal QA builds)

## Risk

- ✅ Code change is 11 lines, standard `Microsoft.AspNetCore.Server.Kestrel.Core` API
- ✅ Default off, so merging this alone has zero runtime effect
- ✅ Rollback = unset env var, no image rebuild required
- ⚠️ When enabled, Unity clients that spend > `delay + 20s` unable to ACK a PING (deep GC pause / blocked main thread) will be disconnected. With `30s` setting that's ~50 s — comfortably above any normal Unity GC pause. Mobile background pods already get cleaned up by the OS in the same window, so no regression.
- StreamingHub semantics are unchanged; PINGs are HTTP/2 layer.

## Related

- planetarium/NineChronicles#7264 — companion client-side change (keepalive + per-call deadlines)
- #2760 — `ActionEvaluationPublisher.RemoveClient` zombie cleanup guard (this PR reduces the window the guard has to compensate for)

## Test plan

- [ ] CI green on `development`
- [ ] Deploy image to internal `remote-headless-1` with `RPC_KEEPALIVE_PING_DELAY_SECONDS=30`
- [ ] 24 h observation: no spurious disconnect spike, no change in CPU/mem profile
- [ ] Deploy to `odin/remote-headless-3` (single mainnet pod)
- [ ] 24 h observation on the same metrics + user-side disconnect reports
- [ ] Roll out remaining pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)